### PR TITLE
`/users` page "code splitting" example

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,6 +15,7 @@ module.exports = {
 		],
 		plugins: [
 			["babel-plugin-transform-react-remove-prop-types", { removeImport: true }],
+			"@babel/plugin-syntax-dynamic-import",
 			"react-hot-loader/babel"
 		]
 	}, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -365,6 +365,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@babel/plugin-proposal-class-properties": "^7.2.0",
     "@babel/plugin-proposal-decorators": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-react": "^7.0.0",

--- a/src/pages/Users.js
+++ b/src/pages/Users.js
@@ -88,14 +88,6 @@ export default function UsersPage() {
 	)
 }
 
-UsersPage.meta = (state) => ({
-	title: 'Simple REST API example',
-	description: 'A list of users',
-	image: 'https://www.famouslogos.us/images/facebook-logo.jpg'
-})
-
-UsersPage.load = async ({ dispatch }) => await dispatch(getUsers())
-
 function Users({
 	users,
 	getUsersPending,

--- a/src/pages/Users.load.js
+++ b/src/pages/Users.load.js
@@ -1,0 +1,3 @@
+import { getUsers } from '../redux/users'
+
+export default async ({ dispatch }) => await dispatch(getUsers())

--- a/src/pages/Users.meta.js
+++ b/src/pages/Users.meta.js
@@ -1,0 +1,5 @@
+export default (state) => ({
+	title: 'Simple REST API example',
+	description: 'A list of users',
+	image: 'https://www.famouslogos.us/images/facebook-logo.jpg'
+})

--- a/src/react-pages.js
+++ b/src/react-pages.js
@@ -12,6 +12,20 @@ export default
 	routes,
 	container,
 
+	// Enable "code splitting" mode.
+	// See `README-CODE-SPLITTING` for more info.
+	// https://github.com/catamphetamine/react-pages/blob/master/README-CODE-SPLITTING.md
+	codeSplit: true,
+
+
+	// When using `codeSplit` with `getComponent`,
+	// route components are loaded after the initial page render.
+	// To hide webpage content until all route components
+	// are resolved one may set `showLoadingInitially` to `true`
+	// and use the exported `<Loading/>` component on the website.
+	//
+	// When not using the `codeSplit` feature:
+	//
 	// When the website is open in a web browser
 	// hide website content under a "preloading" screen
 	// until the application has finished loading.
@@ -22,6 +36,7 @@ export default
 	// in development mode styles are not applied immediately
 	// in a web browser. In production mode CSS styles are
 	// included as `*.css` files so they are applied immediately.
+	//
 	showLoadingInitially: true,
 
 	// Default `<meta/>`.

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,6 @@ import { Route } from 'react-pages'
 
 import Application from './pages/Application'
 
-import Users from './pages/Users'
 import Home from './pages/Home'
 
 import GenericError from './pages/Error'
@@ -22,7 +21,9 @@ export default
 
 		<Route
 			path="users"
-			Component={Users}/>
+			getComponent={() => import('./pages/Users').then(_ => _.default)}
+			load={require('./pages/Users.load').default}
+			meta={require('./pages/Users.meta').default}/>
 
 		<Route
 			path="unauthenticated"


### PR DESCRIPTION
An example of moving the `/users` page into its own component.
All other pages' `.meta` and `.load` functions would have to be also moved to their own files: I didn't do that in this example for brevity.